### PR TITLE
Fix OSC52 copy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Common Setup
         uses: ./.github/actions/setup
       - name: Run isort
-        run: uv run --frozen isort .
+        run: uv run --frozen isort --check .
   black:
     name: black
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
       - name: Common Setup
         uses: ./.github/actions/setup
       - name: Run black
-        run: uv run --frozen black .
+        run: uv run --frozen black --check .
   basedpyright:
     name: basedpyright
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tjex"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tabular Json Explorer"
 readme = "README.md"
 license = "MIT"

--- a/scripts/update_hotkey_table.py
+++ b/scripts/update_hotkey_table.py
@@ -33,6 +33,7 @@ def make_table():
             return e.msg
         raise TjexError("Something went wrong")
 
+
 def main(readme: Path | None):
     set_start_method("forkserver")
 

--- a/src/tjex/config.py
+++ b/src/tjex/config.py
@@ -54,7 +54,11 @@ class Config:
 
     def do_copy(self, s: str):
         if self.copy_command is None:
-            print("\033]52;c;{}\a".format(b64encode(s.encode()).decode()))
+            print(
+                "\033]52;c;{}\a".format(b64encode(s.encode()).decode()),
+                end="",
+                flush=True,
+            )
         else:
             result = sp.run(
                 ["bash", "-c", self.copy_command],

--- a/src/tjex/config.py
+++ b/src/tjex/config.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess as sp
 import tomllib
 from base64 import b64encode
@@ -6,7 +7,6 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, TypeVar
-import re
 
 from tjex.curses_helper import KEY_ALIASES
 from tjex.panel import KeyBindings

--- a/src/tjex/tjex.py
+++ b/src/tjex/tjex.py
@@ -242,7 +242,9 @@ def tjex(
         key = table.col_key
         if key == Undefined():
             raise TjexError("Not an array or object")
-        prompt_append(f"map_values(expand({json.dumps(key, ensure_ascii=False)}))", table.state)
+        prompt_append(
+            f"map_values(expand({json.dumps(key, ensure_ascii=False)}))", table.state
+        )
 
     @table.bindings.add("K")
     def delete_row(_: Any):  # pyright: ignore[reportUnusedFunction]
@@ -381,7 +383,11 @@ def main():
                 KeyReader(scr).get,
                 scr.erase,
                 scr.refresh,
-                **{n: k for n, k in vars(args).items() if n not in {"logfile", "null_input"}},
+                **{
+                    n: k
+                    for n, k in vars(args).items()
+                    if n not in {"logfile", "null_input"}
+                },
             )
 
     return result

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -121,7 +121,9 @@ def run_case(path: Path, update: bool):
                 (
                     Path(i)
                     if isinstance(i, str)
-                    else tmpfile("\n".join(json.dumps(j, ensure_ascii=False) for j in i))
+                    else tmpfile(
+                        "\n".join(json.dumps(j, ensure_ascii=False) for j in i)
+                    )
                 )
                 for i in test_case["inputs"]
             ],

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "tjex"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
Dont print an extra newline character when copying using the OSC52 escape sequence.

Also, fix isort and black CI jobs to actually fix things.