### PR TITLE
Fix BrokenPipeError in jq feed thread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tjex"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Tabular Json Explorer"
 readme = "README.md"
 license = "MIT"

--- a/src/tjex/jq.py
+++ b/src/tjex/jq.py
@@ -94,7 +94,10 @@ def run(command: list[str], inputs: list[Path]):
         except Exception as e:
             feed_exception = e
         finally:
-            p.stdin.close()
+            try:
+                p.stdin.close()
+            except BrokenPipeError:
+                pass
 
     feed_thread = Thread(target=feed, daemon=True)
     feed_thread.start()

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "tjex"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
I can't reliably reproduce it, but apparently `p.stdin` in `jq.run` can be closed already closed when the `feed` thread tries to close it.  
Just ignore the resulting exception.
